### PR TITLE
typo fixed in CMakeLists.txt

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(server server.c)
 
-IF(win32 OR win64)
+IF(WIN32 OR WIN64)
     target_link_libraries(server ws2_32)
 ENDIF()


### PR DESCRIPTION
There was a typo from CMakeLists.txt file which led to linker errors.